### PR TITLE
Add Brent crude futures table

### DIFF
--- a/london_feed_wheat_futures.html
+++ b/london_feed_wheat_futures.html
@@ -2,12 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>London Feed‑Wheat Futures</title>
+  <title>London Feed‑Wheat & Brent Crude Futures</title>
   <style>
     body{font-family:system-ui,Arial,Helvetica,sans-serif;margin:1rem;background:#f9f9f9;color:#222}
     h2{margin-bottom:.5rem}
 
     /* table layout */
+    .tables{display:flex;flex-wrap:wrap;gap:1rem}
+    .tables>div{flex:1;min-width:300px}
+
     table{border-collapse:collapse;width:100%;max-width:480px;background:#fff;box-shadow:0 2px 4px rgba(0,0,0,.06)}
     th,td{padding:.45rem .7rem;border:1px solid #ccc;text-align:right}
     th:first-child,td:first-child{text-align:left}
@@ -27,8 +30,9 @@
     td.flat{color:#555;font-weight:600}
   </style>
   <script>
-    const feedUrl = encodeURIComponent('https://www.noggersblog.co.uk/dalmarkxml/t-enc.asp');
-    const proxy   = 'https://api.allorigins.win/raw?url=' + feedUrl; // CORS proxy
+    const feedUrl  = encodeURIComponent('https://www.noggersblog.co.uk/dalmarkxml/t-enc.asp');
+    const brentUrl = encodeURIComponent('https://www.noggersblog.co.uk/dalmarkxml/brent-enc.asp');
+    const proxy    = 'https://api.allorigins.win/raw?url=';
 
     function classify(num){
       if(isNaN(num)) return 'flat';
@@ -45,7 +49,7 @@
 
     async function loadData(){
       try{
-        const html   = await (await fetch(proxy)).text();
+        const html   = await (await fetch(proxy + feedUrl)).text();
         const doc    = new DOMParser().parseFromString(html,'text/html');
         const tbody  = document.getElementById('data');
         tbody.innerHTML='';
@@ -90,18 +94,79 @@
       }
     }
 
+    async function loadBrentData(){
+      try{
+        const html   = await (await fetch(proxy + brentUrl)).text();
+        const doc    = new DOMParser().parseFromString(html,'text/html');
+        const tbody  = document.getElementById('brentData');
+        tbody.innerHTML='';
+
+        doc.querySelectorAll('tr').forEach(tr=>{
+          const texts  = Array.from(tr.querySelectorAll('td')).map(td=>td.textContent.trim());
+          const values = texts.filter(t=>t!=='');
+          if(values.length===0) return;
+
+          const row=document.createElement('tr');
+
+          if(values.length===1){
+            row.className='timestamp';
+            const cell=document.createElement('td');
+            cell.colSpan=3;
+            cell.textContent=values[0];
+            row.appendChild(cell);
+            tbody.appendChild(row);
+            return;
+          }
+
+          if(values.length>=3){
+            let [contract,last,change] = values;
+            change = change.replace('s','').trim();
+            const changeNum = parseFloat(change.replace(/[^0-9.\-]/g,''));
+            const cls = classify(changeNum);
+
+            [contract,last,arrow(cls)+change].forEach((txt,idx)=>{
+              const cell=document.createElement('td');
+              if(idx===2) cell.className = cls;
+              cell.textContent = txt;
+              row.appendChild(cell);
+            });
+          }
+          tbody.appendChild(row);
+        });
+      }catch(err){
+        console.error('Load error',err);
+        document.getElementById('brentError').textContent='Feed unavailable';
+      }
+    }
+
     loadData();
+    loadBrentData();
     setInterval(loadData,300000);
+    setInterval(loadBrentData,300000);
   </script>
 </head>
 <body>
-  <h2>London Feed‑Wheat Futures (live)</h2>
-  <div id="error" style="color:red"></div>
-  <table>
-    <thead>
-      <tr><th>Contract</th><th>Last</th><th>Change</th></tr>
-    </thead>
-    <tbody id="data"></tbody>
-  </table>
+  <div class="tables">
+    <div>
+      <h2>London Feed‑Wheat Futures (live)</h2>
+      <div id="error" style="color:red"></div>
+      <table>
+        <thead>
+          <tr><th>Contract</th><th>Last</th><th>Change</th></tr>
+        </thead>
+        <tbody id="data"></tbody>
+      </table>
+    </div>
+    <div>
+      <h2>Brent Crude Futures (live)</h2>
+      <div id="brentError" style="color:red"></div>
+      <table>
+        <thead>
+          <tr><th>Contract</th><th>Last</th><th>Change</th></tr>
+        </thead>
+        <tbody id="brentData"></tbody>
+      </table>
+    </div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add CSS flex layout for two tables
- integrate Brent crude futures feed alongside London Feed-Wheat

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68595d3a0b70832ab2c7dd9b5bcced48